### PR TITLE
feedback/empty

### DIFF
--- a/src/lib/components/ui/empty.tsx
+++ b/src/lib/components/ui/empty.tsx
@@ -1,0 +1,69 @@
+import { type HTMLAttributes, type Ref, createElement } from "react";
+import * as Lucide from "lucide-react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const emptyVariants = cva(
+  "flex flex-col items-center justify-center text-gray-500 py-2",
+  {
+    variants: {
+      size: {
+        md: "body02M px-6 gap-y-1",
+        lg: "body01M px-8 gap-y-2",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+);
+
+const iconsVariants = cva("text-inherit", {
+  variants: {
+    size: {
+      md: "w-4 h-4",
+      lg: "w-6 h-6",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+});
+
+export interface EmptyProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof emptyVariants> {
+  icons?: keyof typeof Lucide.icons;
+  iconsClassName?: string;
+  description?: string;
+}
+
+function Empty(
+  {
+    size,
+    icons,
+    description = "Description",
+    className,
+    iconsClassName,
+    ...props
+  }: EmptyProps,
+  ref?: Ref<HTMLDivElement>
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(emptyVariants({ size, className }))}
+      {...props}
+    >
+      {icons &&
+        createElement(Lucide.icons[icons as keyof typeof Lucide.icons], {
+          className: cn(iconsVariants({ size }), iconsClassName),
+        })}
+      <p title={description}>{description}</p>
+    </div>
+  );
+}
+
+export { Empty };

--- a/src/lib/components/ui/empty.tsx
+++ b/src/lib/components/ui/empty.tsx
@@ -1,12 +1,12 @@
-import { type HTMLAttributes, type Ref, createElement } from "react";
-import * as Lucide from "lucide-react";
+import { type HTMLAttributes, type Ref } from "react";
+import { CircleAlert, Inbox } from "lucide-react";
 
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
 const emptyVariants = cva(
-  "flex flex-col items-center justify-center text-gray-500 py-2",
+  "inline-flex flex-col items-center justify-center text-gray-500 py-2",
   {
     variants: {
       size: {
@@ -20,7 +20,7 @@ const emptyVariants = cva(
   }
 );
 
-const iconsVariants = cva("text-inherit", {
+const iconVariants = cva("", {
   variants: {
     size: {
       md: "w-4 h-4",
@@ -35,20 +35,12 @@ const iconsVariants = cva("text-inherit", {
 export interface EmptyProps
   extends HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof emptyVariants> {
-  icons?: keyof typeof Lucide.icons;
-  iconsClassName?: string;
+  icon?: "warning" | "box";
   description?: string;
 }
 
 function Empty(
-  {
-    size,
-    icons,
-    description = "Description",
-    className,
-    iconsClassName,
-    ...props
-  }: EmptyProps,
+  { size, icon, description = "Description", className, ...props }: EmptyProps,
   ref?: Ref<HTMLDivElement>
 ) {
   return (
@@ -57,10 +49,10 @@ function Empty(
       className={cn(emptyVariants({ size, className }))}
       {...props}
     >
-      {icons &&
-        createElement(Lucide.icons[icons as keyof typeof Lucide.icons], {
-          className: cn(iconsVariants({ size }), iconsClassName),
-        })}
+      {icon === "warning" && (
+        <CircleAlert className={cn(iconVariants({ size }))} />
+      )}
+      {icon === "box" && <Inbox className={cn(iconVariants({ size }))} />}
       <p title={description}>{description}</p>
     </div>
   );


### PR DESCRIPTION
- type : HTMLAttributes<HTMLDivElement>
- size : md, lg (default: md)
- icons?: boolean (default: false)
- description?: string
- iconsClassName? : string

피드백 요청 사항
- icons - 현재는 lucide-react icon으로 강제성 부여, 일반 svg나 img 태그 또는 i 태그도 삽입을 가능해야하는지 고민